### PR TITLE
Configure CI to build the "main" branch of langchain4j

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: [11, 17, 21]
+        java: [17, 21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Prepare git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,15 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
+      #  This task will be moved into a nightly build once we have a release.
+      - name: Build langchain4j
+        run: |
+          mkdir langchain4j
+          cd langchain4j
+          git clone https://github.com/langchain4j/langchain4j.git
+          cd langchain4j
+          mvn -B clean install -DskipTests
+
       - name: Build with Maven
         run: mvn -B clean install -Dno-format
 

--- a/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/langchain4j/test/ToolExecutorTest.java
@@ -241,7 +241,7 @@ class ToolExecutorTest {
 
         ToolExecutor toolExecutor = getToolExecutor(methodName);
 
-        String result = toolExecutor.execute(request);
+        String result = toolExecutor.execute(request, null);
 
         assertThat(result).isEqualTo(expectedResult);
     }
@@ -253,7 +253,7 @@ class ToolExecutorTest {
 
         ToolExecutor toolExecutor = getToolExecutor(methodName);
 
-        assertThatThrownBy(() -> toolExecutor.execute(request))
+        assertThatThrownBy(() -> toolExecutor.execute(request, null))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/MethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/MethodImplementationSupport.java
@@ -121,7 +121,7 @@ public class MethodImplementationSupport {
 
             ToolExecutor toolExecutor = context.toolExecutors.get(toolExecutionRequest.name());
             log.debugv("Attempting to execute tool {0}", toolExecutionRequest);
-            String toolExecutionResult = toolExecutor.execute(toolExecutionRequest);
+            String toolExecutionResult = toolExecutor.execute(toolExecutionRequest, memoryId);
             log.debugv("Result of {0} is '{1}'", toolExecutionRequest, toolExecutionResult);
             ToolExecutionResultMessage toolExecutionResultMessage = toolExecutionResultMessage(toolExecutionRequest.name(),
                     toolExecutionResult);

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/tool/QuarkusToolExecutor.java
@@ -31,7 +31,7 @@ public class QuarkusToolExecutor implements ToolExecutor {
         this.argumentMapperClassName = argumentMapperClassName;
     }
 
-    public String execute(ToolExecutionRequest toolExecutionRequest) {
+    public String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId) {
         log.debugv("About to execute {0}", toolExecutionRequest);
 
         ToolInvoker invokerInstance = createInvokerInstance();


### PR DESCRIPTION
1) Make CI green - while we are waiting for a release
2) Adapt code to handle the langchain4j API change
3) Drop CI for java 11 (the extension use 17)