### PR TITLE
Use Langchain 0.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,13 @@ jobs:
           cache: 'maven'
 
       #  This task will be moved into a nightly build once we have a release.
-      - name: Build langchain4j
-        run: |
-          mkdir langchain4j
-          cd langchain4j
-          git clone https://github.com/langchain4j/langchain4j.git
-          cd langchain4j
-          mvn -B clean install -DskipTests
+#      - name: Build langchain4j
+#        run: |
+#          mkdir langchain4j
+#          cd langchain4j
+#          git clone https://github.com/langchain4j/langchain4j.git
+#          cd langchain4j
+#          mvn -B clean install -DskipTests
 
       - name: Build with Maven
         run: mvn -B clean install -Dno-format

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.5.1</quarkus.version>
-    <langchain4j.version>0.23.0</langchain4j.version>
+    <langchain4j.version>0.24.0</langchain4j.version>
     <quarkus-poi.version>2.0.4</quarkus-poi.version>
     <assertj.version>3.24.2</assertj.version>
     <wiremock.version>3.2.0</wiremock.version>


### PR DESCRIPTION
This version contains all the changes we need, so we no longer need to rely on building it from `main`